### PR TITLE
modify for api keys instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ An MCP server implementation for interacting with the Unstructured API. This ser
 
 or use `uv sync`. 
 
-2. Set your Unstructured API key as an environment variable:
+2. Set your Unstructured API key as an environment variable.
    - Create a `.env` file in the root directory, and add a line with your key: `UNSTRUCTURED_API_KEY="YOUR_KEY"` 
 
-Right now only production API is tested. ENV key can be generated in Account Settings -> API Keys -> Generate New Key button
+To test in local, any working key that pointing to prod env would work. However, to be able to return valid results from client's side (e.g, Claude for Desktop), your personal key that is fetched from `https://platform.unstructured.io/app/account/api-keys` is needed. 
+
 ## Running the Server
 Using the MCP CLI:
 ```bash
@@ -180,9 +181,12 @@ To install in Claude Desktop:
 ```
 3. Restart Claude Desktop.
 
+4. Example Issues seen from Claude Desktop.
+    - You will see `No destinations found` when you query for a list of destionation connectors. Check your API key in `.env`, it needs to be your personal key in `https://platform.unstructured.io/app/account/api-keys`.
+
 ## Debugging tools
 
-To spawn UI where each tool can be run individually, use the following command:
+Anthropic provides `MCP Inspector` tool to debug/test your MCP server. Run the following command to spin up a debugging UI. From there, you will be able to add environment variables (pointing to your local env) on the left pane. Include your personal API key there as env var. Go to `tools`, you can test out the capabilities you add to the MCP server. 
 ```
 mcp dev server.py
 ```


### PR DESCRIPTION
the `UNSTRUCTURED_API_KEY` in `.env` file needs user's personal API key fetched from https://platform.unstructured.io/app/account/api-keys.

Adding in the relevant section to update that info. 